### PR TITLE
adding sha256 and sha512 checksums

### DIFF
--- a/src/main/java/com/inventage/nexusaptplugin/DEBIAN.java
+++ b/src/main/java/com/inventage/nexusaptplugin/DEBIAN.java
@@ -33,4 +33,6 @@ public interface DEBIAN {
 
     Field MD5 = new Field( null, DEBIAN_NAMESPACE, "MD5sum", "MD5 checksum" );
     Field FILENAME = new Field( null, DEBIAN_NAMESPACE, "Filename", "Filename" );
+    Field SHA256 = new Field( null, DEBIAN_NAMESPACE, "sha256", "SHA256 checksum" );
+    Field SHA512 = new Field( null, DEBIAN_NAMESPACE, "sha512", "SHA512 checksum" );
 }

--- a/src/main/java/com/inventage/nexusaptplugin/cache/generators/PackagesGenerator.java
+++ b/src/main/java/com/inventage/nexusaptplugin/cache/generators/PackagesGenerator.java
@@ -54,6 +54,9 @@ public class PackagesGenerator
                 continue;
             }
 
+            String sha256 = attrs.get(DEBIAN.SHA256.getFieldName());
+            String sha512 = attrs.get(DEBIAN.SHA512.getFieldName());
+
             // Verify that this is a valid artifact
             w.write("Package: " + attrs.get("Package") + "\n");
             w.write("Version: " + attrs.get("Version") + "\n");
@@ -68,6 +71,14 @@ public class PackagesGenerator
             w.write("Size: " + hit.size + "\n");
             w.write("MD5sum: " + hit.md5 + "\n");
             w.write("SHA1: " + hit.sha1 + "\n");
+
+            if(sha256 != null) {
+                w.write("SHA256: " + sha256 + "\n");
+            }
+            if(sha512 != null) {
+                w.write("SHA512: " + sha512 + "\n");
+            }
+
             w.write("Section: " + attrs.get("Section") + "\n");
             w.write("Priority: " + attrs.get("Priority") + "\n");
             w.write("Description: " + (attrs.get("Description") != null ? (attrs.get("Description").replace("\n", "\n ")) : "<no desc>") + "\n");


### PR DESCRIPTION
Since Debian and Ubuntu Xenial have removed SHA-1 from the list of valid package hashes, it is no longer sufficient to only have an MD5 and SHA1 hash; a SHA256 or SHA512 hash is required. This patch adds these two hashes to the 'Packages' file.

I'm also correcting an apparent race condition in reading the .deb.md5 file that was causing the md5sum to read 'null' instead of the actual md5. The fix was to compute the MD5 at the same time as the SHA hashes since it's basically no extra work.