### PR TITLE
Use SHA-256 in PGP signature.

### DIFF
--- a/src/main/java/com/inventage/nexusaptplugin/cache/generators/ReleaseGPGGenerator.java
+++ b/src/main/java/com/inventage/nexusaptplugin/cache/generators/ReleaseGPGGenerator.java
@@ -40,7 +40,7 @@ public class ReleaseGPGGenerator implements FileGenerator {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         PGPSigner signer = this.aptSigningConfiguration.getSigner();
-        PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(signer.getSecretKey().getPublicKey().getAlgorithm(), PGPUtil.SHA1));
+        PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(signer.getSecretKey().getPublicKey().getAlgorithm(), PGPUtil.SHA256));
         signatureGenerator.init(PGPSignature.BINARY_DOCUMENT, signer.getPrivateKey());
 
         BCPGOutputStream out = new BCPGOutputStream(new ArmoredOutputStream(baos));

--- a/src/main/java/com/inventage/nexusaptplugin/sign/PGPSigner.java
+++ b/src/main/java/com/inventage/nexusaptplugin/sign/PGPSigner.java
@@ -78,7 +78,7 @@ public class PGPSigner {
      * @param output the output destination of the signature
      */
     public void clearSign(InputStream input, OutputStream output) throws IOException, PGPException, GeneralSecurityException {
-        int digest = PGPUtil.SHA1;
+        int digest = PGPUtil.SHA256;
 
         PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(privateKey.getPublicKeyPacket().getAlgorithm(), digest));
         signatureGenerator.init(PGPSignature.CANONICAL_TEXT_DOCUMENT, privateKey);


### PR DESCRIPTION
Ubuntu's APT tool now gives a warning on repositories signed with
"weak digest algorithm (SHA1)".