### PR TITLE
do not rely on system timezone for release file date

### DIFF
--- a/src/main/java/com/inventage/nexusaptplugin/cache/generators/ReleaseGenerator.java
+++ b/src/main/java/com/inventage/nexusaptplugin/cache/generators/ReleaseGenerator.java
@@ -18,6 +18,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 
 public class ReleaseGenerator
@@ -109,6 +110,7 @@ public class ReleaseGenerator
     private String formatDate(Date date) {
         // RFC 2822 format
         final DateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.ENGLISH); 
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
         return format.format(date);
     }
 


### PR DESCRIPTION
This patch will always use GMT TimeZone for the Date field of the release file, instead of relying on the system TimeZone. This should fix the `Invalid 'Date' entry in Release file` warning of apt, as mentioned by @jokr0815 at #18