### PR TITLE
make debian package metadatas cache ttl configurable

### DIFF
--- a/src/main/java/com/inventage/nexusaptplugin/cache/DebianFileManager.java
+++ b/src/main/java/com/inventage/nexusaptplugin/cache/DebianFileManager.java
@@ -29,7 +29,7 @@ public class DebianFileManager {
     @Inject
     public DebianFileManager(AptSigningConfiguration aptSigningConfiguration) {
         this.cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(5, TimeUnit.SECONDS)
+                .expireAfterWrite(Integer.parseInt(System.getProperty("DebianFileManager.cacheTimeoutSeconds", "5")), TimeUnit.SECONDS)
                 .build();
 
         this.generators = new HashMap<String, FileGenerator>();


### PR DESCRIPTION
Generating these from Lucene every 5 seconds can be an enormously expensive operation and cause your nexus server to spend all of it's time doing really slow lucene search queries for "deb" to regenerate this information on the fly.

Before and after:

![screenshot 2018-03-23 10 35 17](https://user-images.githubusercontent.com/519545/37838522-1daa88b6-2e86-11e8-8a3d-5bfa675792da.png)

